### PR TITLE
split-gpg + enigmail: qubes-gpg-client-wrapper is always needed

### DIFF
--- a/security/split-gpg.md
+++ b/security/split-gpg.md
@@ -157,9 +157,7 @@ only `gpg2`). If you encounter trouble while trying to set up Split-GPG, make
 sure you're using `gpg2` for your configuration and testing, since keyring data
 may differ between the two installations.
 
-## Qubes 3.2 Specifics ##
-
-### Using Thunderbird + Enigmail with Split GPG ###
+### Using Thunderbird + Enigmail with Split GPG (Qubes 3.2 and 4.0) ###
 
 However, when using Thunderbird with Enigmail extension it is
 not enough, because Thunderbird doesn't preserve the environment
@@ -175,6 +173,10 @@ the name of the GPG backend VM. This file survives the AppVM reboot, of course.
 
     [user@work ~]$ sudo bash
     [root@work ~]$ echo "work-gpg" > /rw/config/gpg-split-domain
+
+## Qubes 3.2 Specifics ##
+
+None.
 
 ## Qubes 4.0 Specifics ##
 


### PR DESCRIPTION
the section applies to qubes 3.2 (did not check, but it said so)
and to qubes 4.0 (verified, was not obvious before).